### PR TITLE
Register hosts from "PYBLISHHOSTS"

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 from . import version
 import getpass
+import os
 
 from .plugin import (
     Context,
@@ -143,6 +144,11 @@ def __init__():
 
     # Register default host
     register_host("python")
+
+    # Register hosts from environment "PYBLISHHOSTS"
+    for host in os.environ.get("PYBLISHHOSTS", "").split(os.pathsep):
+        if host:
+            register_host(host)
 
     # Register default path
     register_plugin_path("%s/plugins" % __main_package_path())


### PR DESCRIPTION
The environment variable does look a bit odd with double "H", but ```PYBLISHPLUGINPATH``` is without underscores so copying that.